### PR TITLE
Add CS2 single page site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # CS2 Single Page Site
 
-This repository contains a simple single page website about Counter-Strike 2. It demonstrates grenade lineups, tactics and includes a language switcher for English, Russian and Ukrainian.
+This repository contains a single page website about Counter‑Strike&nbsp;2. It shows grenade lineups and tactics videos with a language switcher for English, Russian and Ukrainian.
 
-Open `index.html` in your browser to view the site locally.
+Open `index.html` directly or run a local server such as:
+
+```bash
+python3 -m http.server
+```
+
+Then navigate to `http://localhost:8000/` in your browser.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
-# cs2site
-cs2site
+# CS2 Single Page Site
+
+This repository contains a simple single page website about Counter-Strike 2. It demonstrates grenade lineups, tactics and includes a language switcher for English, Russian and Ukrainian.
+
+Open `index.html` in your browser to view the site locally.

--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,106 @@
+body {
+  margin: 0;
+  font-family: 'Roboto', sans-serif;
+  background-color: #111;
+  color: #f5f5f5;
+}
+
+header {
+  background-color: #1a1a1a;
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.5);
+}
+
+.container {
+  width: 90%;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 20px;
+}
+
+.logo {
+  font-size: 24px;
+  font-weight: 700;
+}
+
+nav ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  gap: 20px;
+}
+
+nav a {
+  color: #f5f5f5;
+  text-decoration: none;
+  transition: color 0.3s;
+}
+
+nav a:hover {
+  color: #0af;
+}
+
+.lang-switcher button {
+  margin-left: 10px;
+  background: #333;
+  color: #f5f5f5;
+  border: none;
+  padding: 5px 10px;
+  cursor: pointer;
+  transition: background 0.3s;
+}
+
+.lang-switcher button:hover {
+  background: #0af;
+}
+
+.header-content {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.section {
+  padding: 60px 0;
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.6s, transform 0.6s;
+}
+
+.section.show {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.video-group {
+  margin-top: 20px;
+}
+
+.videos {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 20px;
+  margin-bottom: 40px;
+}
+
+iframe {
+  width: 100%;
+  max-width: 560px;
+  height: 315px;
+  border: none;
+}
+
+footer {
+  background: #1a1a1a;
+  text-align: center;
+  padding: 20px 0;
+}
+
+@media (min-width: 768px) {
+  .header-content, nav ul {
+    display: flex;
+  }
+}

--- a/css/style.css
+++ b/css/style.css
@@ -1,8 +1,19 @@
 body {
   margin: 0;
   font-family: 'Roboto', sans-serif;
-  background-color: #111;
+  background: url('https://images.pexels.com/photos/7047506/pexels-photo-7047506.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=900&w=1600') no-repeat center/cover fixed;
   color: #f5f5f5;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.8);
+  z-index: -1;
 }
 
 header {
@@ -11,6 +22,12 @@ header {
   top: 0;
   z-index: 1000;
   box-shadow: 0 2px 4px rgba(0,0,0,0.5);
+}
+
+header .container {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
 
 .container {
@@ -57,17 +74,22 @@ nav a:hover {
   background: #0af;
 }
 
-.header-content {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
 
 .section {
   padding: 60px 0;
   opacity: 0;
   transform: translateY(20px);
   transition: opacity 0.6s, transform 0.6s;
+}
+
+.hero {
+  text-align: center;
+  padding: 120px 0;
+}
+
+.hero h1 {
+  font-size: 48px;
+  margin-bottom: 20px;
 }
 
 .section.show {
@@ -100,7 +122,7 @@ footer {
 }
 
 @media (min-width: 768px) {
-  .header-content, nav ul {
+  header .container, nav ul {
     display: flex;
   }
 }

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
     </div>
   </header>
 
-  <section id="home" class="section">
+  <section id="home" class="section hero">
     <div class="container">
       <h1 data-i18n="homeTitle">Welcome</h1>
       <p data-i18n="homeDescription">Learn grenades and tactics.</p>
@@ -46,6 +46,11 @@
           <iframe src="https://www.youtube.com/embed/K8RNLpUoH8Y" allowfullscreen></iframe>
           <iframe src="https://www.youtube.com/embed/wX2N8g6N2uo" allowfullscreen></iframe>
         </div>
+        <h3 data-i18n="mapDust2">Dust2</h3>
+        <div class="videos">
+          <iframe src="https://www.youtube.com/embed/7VYC6hM0aFM" allowfullscreen></iframe>
+          <iframe src="https://www.youtube.com/embed/Eh0k08S-Grc" allowfullscreen></iframe>
+        </div>
         <h3 data-i18n="mapInferno">Inferno</h3>
         <div class="videos">
           <iframe src="https://www.youtube.com/embed/Jaq0QeMEG1A" allowfullscreen></iframe>
@@ -55,6 +60,16 @@
         <div class="videos">
           <iframe src="https://www.youtube.com/embed/FZ2TFmJi-9g" allowfullscreen></iframe>
           <iframe src="https://www.youtube.com/embed/ol-F9OQ60Z8" allowfullscreen></iframe>
+        </div>
+        <h3 data-i18n="mapAnubis">Anubis</h3>
+        <div class="videos">
+          <iframe src="https://www.youtube.com/embed/POsYk8GkYdw" allowfullscreen></iframe>
+          <iframe src="https://www.youtube.com/embed/cXS0epd4G1c" allowfullscreen></iframe>
+        </div>
+        <h3 data-i18n="mapAncient">Ancient</h3>
+        <div class="videos">
+          <iframe src="https://www.youtube.com/embed/OkIav3L2NHg" allowfullscreen></iframe>
+          <iframe src="https://www.youtube.com/embed/v4nLgxT5HFw" allowfullscreen></iframe>
         </div>
       </div>
     </div>
@@ -67,6 +82,7 @@
       <div class="video-group">
         <iframe src="https://www.youtube.com/embed/Ta5RZBpmcRI" allowfullscreen></iframe>
         <iframe src="https://www.youtube.com/embed/bTCRvAMxAkE" allowfullscreen></iframe>
+        <iframe src="https://www.youtube.com/embed/YAVKjT1HV00" allowfullscreen></iframe>
       </div>
     </div>
   </section>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Counter-Strike 2 Guide</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <div class="logo" data-i18n="title">Counter-Strike 2 Guide</div>
+      <nav>
+        <ul>
+          <li><a href="#home" data-i18n="navHome">Home</a></li>
+          <li><a href="#grenades" data-i18n="navGrenades">Grenades</a></li>
+          <li><a href="#tactics" data-i18n="navTactics">Tactics</a></li>
+          <li><a href="#contacts" data-i18n="navContacts">Contacts</a></li>
+        </ul>
+      </nav>
+      <div class="lang-switcher">
+        <button data-lang="en">EN</button>
+        <button data-lang="ru">RU</button>
+        <button data-lang="uk">UA</button>
+      </div>
+    </div>
+  </header>
+
+  <section id="home" class="section">
+    <div class="container">
+      <h1 data-i18n="homeTitle">Welcome</h1>
+      <p data-i18n="homeDescription">Learn grenades and tactics.</p>
+    </div>
+  </section>
+
+  <section id="grenades" class="section">
+    <div class="container">
+      <h2 data-i18n="grenadesTitle">Grenades</h2>
+      <p data-i18n="grenadesDescription">Useful grenade lineups for maps.</p>
+      <div class="video-group">
+        <h3 data-i18n="mapMirage">Mirage</h3>
+        <div class="videos">
+          <iframe src="https://www.youtube.com/embed/K8RNLpUoH8Y" allowfullscreen></iframe>
+          <iframe src="https://www.youtube.com/embed/wX2N8g6N2uo" allowfullscreen></iframe>
+        </div>
+        <h3 data-i18n="mapInferno">Inferno</h3>
+        <div class="videos">
+          <iframe src="https://www.youtube.com/embed/Jaq0QeMEG1A" allowfullscreen></iframe>
+          <iframe src="https://www.youtube.com/embed/1bL3dc0G1dQ" allowfullscreen></iframe>
+        </div>
+        <h3 data-i18n="mapNuke">Nuke</h3>
+        <div class="videos">
+          <iframe src="https://www.youtube.com/embed/FZ2TFmJi-9g" allowfullscreen></iframe>
+          <iframe src="https://www.youtube.com/embed/ol-F9OQ60Z8" allowfullscreen></iframe>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section id="tactics" class="section">
+    <div class="container">
+      <h2 data-i18n="tacticsTitle">Tactics</h2>
+      <p data-i18n="tacticsDescription">Strategies for Wingman and Competitive.</p>
+      <div class="video-group">
+        <iframe src="https://www.youtube.com/embed/Ta5RZBpmcRI" allowfullscreen></iframe>
+        <iframe src="https://www.youtube.com/embed/bTCRvAMxAkE" allowfullscreen></iframe>
+      </div>
+    </div>
+  </section>
+
+  <section id="contacts" class="section">
+    <div class="container">
+      <h2 data-i18n="contactsTitle">Contacts</h2>
+      <p data-i18n="contactsDescription">Telegram: @ya_fa1d</p>
+    </div>
+  </section>
+
+  <footer>
+    <div class="container">
+      &copy; 2024 CS2 Guide
+    </div>
+  </footer>
+
+  <script src="js/script.js"></script>
+</body>
+</html>

--- a/js/script.js
+++ b/js/script.js
@@ -1,5 +1,5 @@
 function loadLanguage(lang) {
-  fetch('lang/' + lang + '.json')
+  fetch('./lang/' + lang + '.json')
     .then(res => res.json())
     .then(data => {
       document.querySelectorAll('[data-i18n]').forEach(el => {
@@ -13,11 +13,14 @@ function loadLanguage(lang) {
         }
       });
       document.documentElement.lang = lang;
-    });
+      localStorage.setItem('lang', lang);
+    })
+    .catch(err => console.error('Translation load error', err));
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-  loadLanguage('en');
+  const current = localStorage.getItem('lang') || 'en';
+  loadLanguage(current);
   document.querySelectorAll('.lang-switcher button').forEach(btn => {
     btn.addEventListener('click', () => loadLanguage(btn.dataset.lang));
   });

--- a/js/script.js
+++ b/js/script.js
@@ -1,0 +1,34 @@
+function loadLanguage(lang) {
+  fetch('lang/' + lang + '.json')
+    .then(res => res.json())
+    .then(data => {
+      document.querySelectorAll('[data-i18n]').forEach(el => {
+        const key = el.getAttribute('data-i18n');
+        if (data[key]) {
+          if (el.tagName.toLowerCase() === 'input') {
+            el.placeholder = data[key];
+          } else {
+            el.textContent = data[key];
+          }
+        }
+      });
+      document.documentElement.lang = lang;
+    });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  loadLanguage('en');
+  document.querySelectorAll('.lang-switcher button').forEach(btn => {
+    btn.addEventListener('click', () => loadLanguage(btn.dataset.lang));
+  });
+
+  const observer = new IntersectionObserver(entries => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        entry.target.classList.add('show');
+      }
+    });
+  }, { threshold: 0.1 });
+
+  document.querySelectorAll('.section').forEach(section => observer.observe(section));
+});

--- a/lang/en.json
+++ b/lang/en.json
@@ -14,5 +14,8 @@
   "contactsDescription": "Telegram: @ya_fa1d",
   "mapMirage": "Mirage",
   "mapInferno": "Inferno",
-  "mapNuke": "Nuke"
+  "mapNuke": "Nuke",
+  "mapDust2": "Dust2",
+  "mapAnubis": "Anubis",
+  "mapAncient": "Ancient"
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -1,0 +1,18 @@
+{
+  "title": "Counter-Strike 2 Guide",
+  "navHome": "Home",
+  "navGrenades": "Grenades",
+  "navTactics": "Tactics",
+  "navContacts": "Contacts",
+  "homeTitle": "Welcome to the CS2 Guide",
+  "homeDescription": "Learn grenades and tactics for Counter-Strike 2.",
+  "grenadesTitle": "Grenades",
+  "grenadesDescription": "Useful grenade lineups for popular maps.",
+  "tacticsTitle": "Tactics",
+  "tacticsDescription": "Strategies for Wingman and Competitive modes.",
+  "contactsTitle": "Contacts",
+  "contactsDescription": "Telegram: @ya_fa1d",
+  "mapMirage": "Mirage",
+  "mapInferno": "Inferno",
+  "mapNuke": "Nuke"
+}

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -14,5 +14,8 @@
   "contactsDescription": "Telegram: @ya_fa1d",
   "mapMirage": "Mirage",
   "mapInferno": "Inferno",
-  "mapNuke": "Nuke"
+  "mapNuke": "Nuke",
+  "mapDust2": "Dust2",
+  "mapAnubis": "Anubis",
+  "mapAncient": "Ancient"
 }

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -1,0 +1,18 @@
+{
+  "title": "Гайд по Counter-Strike 2",
+  "navHome": "Главная",
+  "navGrenades": "Раскидки",
+  "navTactics": "Тактики",
+  "navContacts": "Контакты",
+  "homeTitle": "Добро пожаловать в гайд по CS2",
+  "homeDescription": "Учите раскидки и тактики для Counter-Strike 2.",
+  "grenadesTitle": "Раскидки",
+  "grenadesDescription": "Полезные раскидки на популярных картах.",
+  "tacticsTitle": "Тактики",
+  "tacticsDescription": "Стратегии для режимов \"Напарники\" и \"Соревновательный\".",
+  "contactsTitle": "Контакты",
+  "contactsDescription": "Telegram: @ya_fa1d",
+  "mapMirage": "Mirage",
+  "mapInferno": "Inferno",
+  "mapNuke": "Nuke"
+}

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -14,5 +14,8 @@
   "contactsDescription": "Telegram: @ya_fa1d",
   "mapMirage": "Mirage",
   "mapInferno": "Inferno",
-  "mapNuke": "Nuke"
+  "mapNuke": "Nuke",
+  "mapDust2": "Dust2",
+  "mapAnubis": "Anubis",
+  "mapAncient": "Ancient"
 }

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -1,0 +1,18 @@
+{
+  "title": "Гайд по Counter-Strike 2",
+  "navHome": "Головна",
+  "navGrenades": "Гранати",
+  "navTactics": "Тактики",
+  "navContacts": "Контакти",
+  "homeTitle": "Ласкаво просимо до гайду CS2",
+  "homeDescription": "Вивчайте гранати і тактики для Counter-Strike 2.",
+  "grenadesTitle": "Гранати",
+  "grenadesDescription": "Корисні гранати на популярних картах.",
+  "tacticsTitle": "Тактики",
+  "tacticsDescription": "Стратегії для режимів \"Напарники\" та \"Змагальний\".",
+  "contactsTitle": "Контакти",
+  "contactsDescription": "Telegram: @ya_fa1d",
+  "mapMirage": "Mirage",
+  "mapInferno": "Inferno",
+  "mapNuke": "Nuke"
+}


### PR DESCRIPTION
## Summary
- create a simple single page site on Counter‑Strike 2
- add translations for English, Russian and Ukrainian
- implement CSS for dark esports style
- use JavaScript to switch languages and animate sections

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683f660f34c0832eaaf693b9095fe44a