### PR TITLE
Add cheat scanner script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build/
+dist/
+*.spec

--- a/cheat_scanner.py
+++ b/cheat_scanner.py
@@ -1,6 +1,16 @@
 import tkinter as tk
 from tkinter import ttk
 import winsound
+import random
+
+CHEATS = [
+    "XONE",
+    "Midnight",
+    "Predator.systems",
+    "Nixware",
+    "MemeSense",
+    "Neverlose",
+]
 
 class CheatScanner:
     def __init__(self, root):
@@ -13,7 +23,9 @@ class CheatScanner:
         self.update_progress(0)
 
     def update_progress(self, step):
-        if step <= 30:
+        if step < 30:
+            cheat = random.choice(CHEATS)
+            self.label.config(text=f"Scanning for {cheat}...")
             self.progress['value'] = step
             self.root.after(1000, self.update_progress, step + 1)
         else:
@@ -24,7 +36,7 @@ class CheatScanner:
         try:
             winsound.PlaySound('siren.wav', winsound.SND_FILENAME | winsound.SND_ASYNC)
         except Exception:
-            pass
+            winsound.Beep(1000, 1500)
         self.root.protocol("WM_DELETE_WINDOW", self.disable_close)
         self.root.after(5000, self.enable_close)
 

--- a/cheat_scanner.py
+++ b/cheat_scanner.py
@@ -1,0 +1,44 @@
+import tkinter as tk
+from tkinter import ttk
+import winsound
+
+class CheatScanner:
+    def __init__(self, root):
+        self.root = root
+        root.title("Cheat Scanner")
+        self.label = tk.Label(root, text="Scanning for cheats...")
+        self.label.pack(padx=20, pady=10)
+        self.progress = ttk.Progressbar(root, length=300, maximum=30)
+        self.progress.pack(padx=20, pady=10)
+        self.update_progress(0)
+
+    def update_progress(self, step):
+        if step <= 30:
+            self.progress['value'] = step
+            self.root.after(1000, self.update_progress, step + 1)
+        else:
+            self.detected()
+
+    def detected(self):
+        self.label.config(text="Cheats detected on your system!", fg="red", font=("TkDefaultFont", 12, "bold"))
+        try:
+            winsound.PlaySound('siren.wav', winsound.SND_FILENAME | winsound.SND_ASYNC)
+        except Exception:
+            pass
+        self.root.protocol("WM_DELETE_WINDOW", self.disable_close)
+        self.root.after(5000, self.enable_close)
+
+    def disable_close(self):
+        pass
+
+    def enable_close(self):
+        self.root.protocol("WM_DELETE_WINDOW", self.root.destroy)
+
+
+def main():
+    root = tk.Tk()
+    app = CheatScanner(root)
+    root.mainloop()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `cheat_scanner.py` that shows a progress bar, detects cheats after 30s, plays a sound, and temporarily disables closing

## Testing
- `python3 cheat_scanner.py`

------
https://chatgpt.com/codex/tasks/task_e_68512493f348832e81eab7dbb6bb0b6c