### PR TITLE
Add browser Tic Tac Toe game

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -126,3 +126,38 @@ footer {
     display: flex;
   }
 }
+
+/* Tic Tac Toe styles */
+.tic-board {
+  display: grid;
+  grid-template-columns: repeat(3, 100px);
+  grid-template-rows: repeat(3, 100px);
+  gap: 5px;
+  margin: 20px auto;
+}
+
+.tic-cell {
+  width: 100px;
+  height: 100px;
+  background: rgba(255, 255, 255, 0.1);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 48px;
+  cursor: pointer;
+}
+
+.tic-cell.taken {
+  cursor: default;
+}
+
+.message {
+  margin-top: 20px;
+  font-size: 24px;
+}
+
+#tic-reset {
+  margin-top: 20px;
+  padding: 10px 20px;
+  font-size: 16px;
+}

--- a/css/style.css
+++ b/css/style.css
@@ -127,6 +127,17 @@ footer {
   }
 }
 
+.tic-choice {
+  margin: 20px 0;
+  text-align: center;
+}
+
+.tic-choice button {
+  margin: 0 5px;
+  padding: 8px 16px;
+  font-size: 16px;
+}
+
 /* Tic Tac Toe styles */
 .tic-board {
   display: grid;

--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
           <li><a href="#grenades" data-i18n="navGrenades">Grenades</a></li>
           <li><a href="#tactics" data-i18n="navTactics">Tactics</a></li>
           <li><a href="#contacts" data-i18n="navContacts">Contacts</a></li>
+          <li><a href="tictactoe.html" data-i18n="navTicTacToe">Tic Tac Toe</a></li>
         </ul>
       </nav>
       <div class="lang-switcher">

--- a/js/tictactoe.js
+++ b/js/tictactoe.js
@@ -1,0 +1,54 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const cells = Array.from(document.querySelectorAll('.tic-cell'));
+  const message = document.getElementById('tic-message');
+  const resetBtn = document.getElementById('tic-reset');
+  let currentPlayer = 'X';
+  const board = Array(9).fill(null);
+
+  const wins = [
+    [0, 1, 2],
+    [3, 4, 5],
+    [6, 7, 8],
+    [0, 3, 6],
+    [1, 4, 7],
+    [2, 5, 8],
+    [0, 4, 8],
+    [2, 4, 6]
+  ];
+
+  function checkWin(player) {
+    return wins.some(combo => combo.every(i => board[i] === player));
+  }
+
+  function checkDraw() {
+    return board.every(Boolean);
+  }
+
+  function handleClick(e) {
+    const idx = cells.indexOf(e.target);
+    if (board[idx] || message.textContent) return;
+    board[idx] = currentPlayer;
+    e.target.textContent = currentPlayer;
+    e.target.classList.add('taken');
+
+    if (checkWin(currentPlayer)) {
+      message.textContent = `${currentPlayer} wins!`;
+    } else if (checkDraw()) {
+      message.textContent = 'Draw!';
+    } else {
+      currentPlayer = currentPlayer === 'X' ? 'O' : 'X';
+    }
+  }
+
+  cells.forEach(cell => cell.addEventListener('click', handleClick));
+
+  resetBtn.addEventListener('click', () => {
+    board.fill(null);
+    cells.forEach(c => {
+      c.textContent = '';
+      c.classList.remove('taken');
+    });
+    message.textContent = '';
+    currentPlayer = 'X';
+  });
+});

--- a/js/tictactoe.js
+++ b/js/tictactoe.js
@@ -2,6 +2,12 @@ document.addEventListener('DOMContentLoaded', () => {
   const cells = Array.from(document.querySelectorAll('.tic-cell'));
   const message = document.getElementById('tic-message');
   const resetBtn = document.getElementById('tic-reset');
+  const choiceBox = document.getElementById('tic-choice');
+  const chooseX = document.getElementById('choose-x');
+  const chooseO = document.getElementById('choose-o');
+
+  let playerSymbol = null;
+  let aiSymbol = null;
   let currentPlayer = 'X';
   const board = Array(9).fill(null);
 
@@ -24,25 +30,85 @@ document.addEventListener('DOMContentLoaded', () => {
     return board.every(Boolean);
   }
 
+  function evaluate() {
+    if (checkWin(playerSymbol)) {
+      message.textContent = 'You win!';
+      return true;
+    }
+    if (checkWin(aiSymbol)) {
+      message.textContent = 'AI wins!';
+      return true;
+    }
+    if (checkDraw()) {
+      message.textContent = 'Draw!';
+      return true;
+    }
+    return false;
+  }
+
+  function aiMove() {
+    const free = board
+      .map((v, i) => (v ? null : i))
+      .filter(i => i !== null);
+    if (free.length === 0) return;
+    const idx = free[Math.floor(Math.random() * free.length)];
+    board[idx] = aiSymbol;
+    cells[idx].textContent = aiSymbol;
+    cells[idx].classList.add('taken');
+  }
+
   function handleClick(e) {
     const idx = cells.indexOf(e.target);
-    if (board[idx] || message.textContent) return;
-    board[idx] = currentPlayer;
-    e.target.textContent = currentPlayer;
+    if (
+      board[idx] ||
+      message.textContent ||
+      currentPlayer !== playerSymbol ||
+      !playerSymbol
+    )
+      return;
+
+    board[idx] = playerSymbol;
+    e.target.textContent = playerSymbol;
     e.target.classList.add('taken');
 
-    if (checkWin(currentPlayer)) {
-      message.textContent = `${currentPlayer} wins!`;
-    } else if (checkDraw()) {
-      message.textContent = 'Draw!';
-    } else {
-      currentPlayer = currentPlayer === 'X' ? 'O' : 'X';
-    }
+    if (evaluate()) return;
+
+    currentPlayer = aiSymbol;
+    setTimeout(() => {
+      aiMove();
+      if (evaluate()) return;
+      currentPlayer = playerSymbol;
+    }, 300);
   }
 
   cells.forEach(cell => cell.addEventListener('click', handleClick));
 
+  function startGame(sym) {
+    playerSymbol = sym;
+    aiSymbol = sym === 'X' ? 'O' : 'X';
+    currentPlayer = 'X';
+    choiceBox.style.display = 'none';
+    message.textContent = '';
+    board.fill(null);
+    cells.forEach(c => {
+      c.textContent = '';
+      c.classList.remove('taken');
+    });
+    if (aiSymbol === 'X') {
+      currentPlayer = aiSymbol;
+      aiMove();
+      evaluate();
+      currentPlayer = playerSymbol;
+    }
+  }
+
+  chooseX.addEventListener('click', () => startGame('X'));
+  chooseO.addEventListener('click', () => startGame('O'));
+
   resetBtn.addEventListener('click', () => {
+    choiceBox.style.display = 'block';
+    playerSymbol = null;
+    aiSymbol = null;
     board.fill(null);
     cells.forEach(c => {
       c.textContent = '';

--- a/lang/en.json
+++ b/lang/en.json
@@ -17,5 +17,8 @@
   "mapNuke": "Nuke",
   "mapDust2": "Dust2",
   "mapAnubis": "Anubis",
-  "mapAncient": "Ancient"
+  "mapAncient": "Ancient",
+  "navTicTacToe": "Tic Tac Toe",
+  "ticTitle": "Tic Tac Toe",
+  "ticReset": "Restart Game"
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -20,5 +20,6 @@
   "mapAncient": "Ancient",
   "navTicTacToe": "Tic Tac Toe",
   "ticTitle": "Tic Tac Toe",
+  "ticChoose": "Choose X or O",
   "ticReset": "Restart Game"
 }

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -17,5 +17,8 @@
   "mapNuke": "Nuke",
   "mapDust2": "Dust2",
   "mapAnubis": "Anubis",
-  "mapAncient": "Ancient"
+  "mapAncient": "Ancient",
+  "navTicTacToe": "Крестики-нолики",
+  "ticTitle": "Крестики-нолики",
+  "ticReset": "Перезапустить игру"
 }

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -20,5 +20,6 @@
   "mapAncient": "Ancient",
   "navTicTacToe": "Крестики-нолики",
   "ticTitle": "Крестики-нолики",
+  "ticChoose": "Выберите X или O",
   "ticReset": "Перезапустить игру"
 }

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -20,5 +20,6 @@
   "mapAncient": "Ancient",
   "navTicTacToe": "Хрестики-нулики",
   "ticTitle": "Хрестики-нулики",
+  "ticChoose": "Виберіть X або O",
   "ticReset": "Перезапустити гру"
 }

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -17,5 +17,8 @@
   "mapNuke": "Nuke",
   "mapDust2": "Dust2",
   "mapAnubis": "Anubis",
-  "mapAncient": "Ancient"
+  "mapAncient": "Ancient",
+  "navTicTacToe": "Хрестики-нулики",
+  "ticTitle": "Хрестики-нулики",
+  "ticReset": "Перезапустити гру"
 }

--- a/tictactoe.html
+++ b/tictactoe.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tic Tac Toe</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+  <header>
+    <div class="container">
+      <div class="logo" data-i18n="title">Counter-Strike 2 Guide</div>
+      <nav>
+        <ul>
+          <li><a href="index.html#home" data-i18n="navHome">Home</a></li>
+          <li><a href="index.html#grenades" data-i18n="navGrenades">Grenades</a></li>
+          <li><a href="index.html#tactics" data-i18n="navTactics">Tactics</a></li>
+          <li><a href="index.html#contacts" data-i18n="navContacts">Contacts</a></li>
+          <li><a href="tictactoe.html" data-i18n="navTicTacToe">Tic Tac Toe</a></li>
+        </ul>
+      </nav>
+      <div class="lang-switcher">
+        <button data-lang="en">EN</button>
+        <button data-lang="ru">RU</button>
+        <button data-lang="uk">UA</button>
+      </div>
+    </div>
+  </header>
+
+  <section class="section hero">
+    <div class="container">
+      <h1 data-i18n="ticTitle">Tic Tac Toe</h1>
+      <div id="tic-board" class="tic-board">
+        <div class="tic-cell"></div>
+        <div class="tic-cell"></div>
+        <div class="tic-cell"></div>
+        <div class="tic-cell"></div>
+        <div class="tic-cell"></div>
+        <div class="tic-cell"></div>
+        <div class="tic-cell"></div>
+        <div class="tic-cell"></div>
+        <div class="tic-cell"></div>
+      </div>
+      <div id="tic-message" class="message"></div>
+      <button id="tic-reset" data-i18n="ticReset">Restart</button>
+    </div>
+  </section>
+
+  <footer>
+    <div class="container">
+      &copy; 2024 CS2 Guide
+    </div>
+  </footer>
+
+  <script src="js/script.js"></script>
+  <script src="js/tictactoe.js"></script>
+</body>
+</html>

--- a/tictactoe.html
+++ b/tictactoe.html
@@ -33,6 +33,11 @@
   <section class="section hero">
     <div class="container">
       <h1 data-i18n="ticTitle">Tic Tac Toe</h1>
+      <div id="tic-choice" class="tic-choice">
+        <p data-i18n="ticChoose">Choose X or O</p>
+        <button id="choose-x">X</button>
+        <button id="choose-o">O</button>
+      </div>
       <div id="tic-board" class="tic-board">
         <div class="tic-cell"></div>
         <div class="tic-cell"></div>


### PR DESCRIPTION
## Summary
- add Tic Tac Toe page with board and controls
- implement game logic in `tictactoe.js`
- style the game board
- link to the new page from the main navigation
- update translations for the new navigation item

## Testing
- `node -c js/tictactoe.js`


------
https://chatgpt.com/codex/tasks/task_e_686018d8fe14832eb675e7e48cd0dfc1